### PR TITLE
feat: be able to read default stencil files

### DIFF
--- a/src/ch/w3tec/stencil/StencilDocReader.java
+++ b/src/ch/w3tec/stencil/StencilDocReader.java
@@ -5,13 +5,16 @@ import com.google.gson.Gson;
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.DataConstants;
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.fileEditor.impl.LoadTextUtil;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.search.FilenameIndex;
+import com.intellij.openapi.project.ProjectManager;
 
-import java.util.Collection;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class StencilDocReader {
 
@@ -24,28 +27,33 @@ public class StencilDocReader {
         doc.ifPresent(value -> this.stencilDoc = value);
     }
 
+    private List<Path> getAllStencilDocs(String projectBasePath) throws IOException {
+        Path path = Paths.get(projectBasePath);
+        return Files.walk(path)
+                .filter(Files::isRegularFile)
+                .filter(file -> file.toAbsolutePath().toString().contains("dist/docs.json"))
+                .collect(Collectors.toList());
+    }
+
     private Optional<StencilDoc> deserialize() {
-        DataContext dataContext = DataManager.getInstance().getDataContext();
-        Project project = (Project) dataContext.getData(DataConstants.PROJECT);
+        Project project = ProjectManager.getInstance().getOpenProjects()[0];
 
-        if (project != null) {
-            Collection<VirtualFile> files = FilenameIndex.getAllFilesByExt(project, "json");
-            Optional<VirtualFile> file = files.stream()
-                    .filter(virtualFile -> virtualFile != null
-                            && virtualFile.getCanonicalPath() != null
-                            && virtualFile.getCanonicalPath().contains("bal-ui-library")
-                            && virtualFile.getCanonicalPath().endsWith("dist/package.json"))
-                    .findFirst();
-
-            if (file.isPresent()) {
-                Gson gson = new Gson();
-                return Optional.of(gson.fromJson(LoadTextUtil.loadText(file.get()).toString(), StencilDoc.class));
+        if (project != null && project.getBasePath() != null) {
+            try {
+                List<Path> allStencilDocs = getAllStencilDocs(project.getBasePath());
+                // OPTIMIZE: be able to read multiple files
+                if (allStencilDocs.size() > 0) {
+                    Gson gson = new Gson();
+                    // OPTIMIZE: check for docs.json files that they actually are from stencil
+                    String json = String.join("", Files.readAllLines(allStencilDocs.iterator().next()));
+                    return Optional.of(gson.fromJson(json, StencilDoc.class));
+                }
+            } catch (Exception e) {
+                return Optional.empty();
             }
-
         }
 
         return Optional.empty();
-
     }
 
 }


### PR DESCRIPTION
Possible solution to read all stencil files (dist/docs.json): Don't use IntelliJ's virtual file system but Java.IO? 
Please let me know if you have any knowledge of drawbacks w/ that solution.